### PR TITLE
Fallback to fetching pages from Workers KV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,21 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@cloudflare/kv-asset-handler": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.0.12.tgz",
+      "integrity": "sha512-3XCs9TRhQh/yUs1ST9cIMLB8C5c1JRKcDYTPJbAmcgI0kO2FPCSZz+kyNb9x25DuGQeqOMMwmxHPtiOfTki/Gw==",
+      "requires": {
+        "@cloudflare/workers-types": "^2.0.0",
+        "@types/mime": "^2.0.2",
+        "mime": "^2.4.6"
+      }
+    },
+    "@cloudflare/workers-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-2.1.0.tgz",
+      "integrity": "sha512-VmXaHTq0lt6Xre4aK1hUK25hjZjuEUkHtdUEt0FJamv+NzQO54Gwp6Zr5Cfu6SP5EQ/tTmTMP/tK9npA8zhcCg=="
+    },
     "@types/eslint": {
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.5.tgz",
@@ -35,6 +50,11 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
       "dev": true
+    },
+    "@types/mime": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
+      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q=="
     },
     "@types/node": {
       "version": "14.14.8",
@@ -620,6 +640,11 @@
         "braces": "^3.0.1",
         "picomatch": "^2.0.5"
       }
+    },
+    "mime": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
     },
     "mime-db": {
       "version": "1.44.0",

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
     "ts-loader": "^8.0.11",
     "typescript": "^4.0.5",
     "webpack": "^5.5.1"
+  },
+  "dependencies": {
+    "@cloudflare/kv-asset-handler": "0.0.12"
   }
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -4,17 +4,16 @@ const APS_SLUG = 'Android-Password-Store/Android-Password-Store'
 const GITHUB_URL = `https://github.com/${GITHUB_USERNAME}`
 const APS_GITHUB_URL = `https://github.com/${APS_SLUG}`
 
-export async function handleRequest(request: Request): Promise<Response> {
-  if (request.url.startsWith(BASE_URL)) {
-    return redirectGitHub(request)
+export async function handleRequest(event: FetchEvent): Promise<Response> {
+  if (event.request.url.startsWith(BASE_URL)) {
+    return redirectGitHub(event)
   } else {
-    return fetch(request)
+    return fetch(event.request)
   }
 }
 
-
-async function redirectGitHub(request: Request): Promise<Response> {
-  const urlParts = request.url.replace(BASE_URL, '').split('/')
+async function redirectGitHub(event: FetchEvent): Promise<Response> {
+  const urlParts = event.request.url.replace(BASE_URL, '').split('/')
   switch (urlParts[0]) {
     case 'g':
       switch (urlParts.length) {
@@ -44,5 +43,5 @@ async function redirectGitHub(request: Request): Promise<Response> {
           )
       }
   }
-  return fetch(request)
+  return fetch(event.request)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import { handleRequest } from './handler'
 
 addEventListener('fetch', (event) => {
-  event.respondWith(handleRequest(event.request))
+  if (event instanceof FetchEvent) {
+    event.respondWith(handleRequest(event))
+  }
 })


### PR DESCRIPTION
The way `redirekt` was built was to sit as an intermediate layer between a browser and the origin server to redirect if needed, and fall back to simply fetching from the origin if no rules matched. Since I have moved my site to Workers KV, this PR ports the changes I made to redirekt's original code in my website's repo, to the original source. This will also allow me to write a thorough analysis of the exact changes as a blog post :)